### PR TITLE
fix xrange being called instead of range

### DIFF
--- a/pebble_tool/commands/screenshot.py
+++ b/pebble_tool/commands/screenshot.py
@@ -141,7 +141,7 @@ class ScreenshotCommand(PebbleCommand):
         roundness.extend(reversed(roundness))
         if should_roundify:
             for row, skip in zip(rgba, roundness):
-                for x in xrange(3, len(row), 4):
+                for x in range(3, len(row), 4):
                     if not skip <= x // 4 < len(row) // 4 - skip:
                         row[x] = 0
         return rgba


### PR DESCRIPTION
this fixes an error thrown when taking screenshots of a chalk emulator. Fixes #3 