### PR TITLE
Basic Microsoft Windows support #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ It seems there's currently some state management bug where _two_ instances of py
 
 If you encounter this, a quick (and probably unwise fix) is to run `rebble wipe`, which should clear out the stored PIDs of pypkjs and allow you to install a something successfully into the emulator. You might need to manually kill the old processes. It seems there ends up to be two instances of pypkjs, one of which is connected, and the other which crashes.
 
+## Windows note
+
+Windows is NOT a supported platform for Pebble (outside of WSL).
+
+However you can get debug trace on native Windows using Python 2.7
+by checking out the code and issuing:
+
+    python -m pip install -r requirements_py27win.txt
+
+Debug trace can be accessed via:
+
+    python pebble.py logs --phone IP_ADDRESS_HERE
+
+Alternatively `setup.py` can be called with the usual `develop` or `install`
+parameter.
+
 ## TODO
 - [x] Make the cli tool start up
 - [x] Make the build system run as-is

--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ Windows is NOT a supported platform for Pebble (outside of WSL).
 However you can get debug trace on native Windows using Python 2.7
 by checking out the code and issuing:
 
-    python -m pip install -r requirements_py27win.txt
+    py -3 -m py3venv
+    python -m pip install -r requirements.txt
 
 Debug trace can be accessed via:
 
     python pebble.py logs --phone IP_ADDRESS_HERE
+    python pebble.py install --logs --phone IP_ADDRESS_HERE YOUR.pbw
 
 Alternatively `setup.py` can be called with the usual `develop` or `install`
 parameter.

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,5 @@ sh==2.2.1
 # https://github.com/richinfante/pypkjs
 # https://github.com/richinfante/libpebble2
 https://public.richinfante.com/rebble/libpebble2-0.0.29.tar.gz
-https://public.richinfante.com/rebble/pypkjs-1.1.11.tar.gz
+https://public.richinfante.com/rebble/pypkjs-1.1.11.tar.gz; sys_platform != "win32"  # No SDK/emulator for Microsoft Windows
+pyreadline3; sys_platform == "win32"  # Microsoft Windows doesn't include readline


### PR DESCRIPTION
Allows Windows machines to (natively) monitor logging of Pebble apps.